### PR TITLE
Feat  xbar layout

### DIFF
--- a/src/accessibility.js
+++ b/src/accessibility.js
@@ -1,19 +1,26 @@
-//array access layer
+import {
+  pipe,
+  pipeCompatibleFilter,
+  pipeCompatibleMap,
+  pipeCompatibleReduce,
+  pipeCompatibleSplit,
+} from './utility.js';
+// array access layer
 const lastIndex = (arr) => arr.length - 1;
 const lastItem = (arr) => arr[lastIndex(arr)];
 
-//array element transform layer
+// array element transform layer
 const appendLastLine = (lines, word) => [
   ...lines.slice(0, lastIndex(lines)),
   lastItem(lines).concat(' ', word),
 ];
 const newLine = (lines, newLine) => lines.concat(newLine);
 
-//conditional logic layer
+// conditional logic layer
 const isUnderLimit = (line, word, lineLength) =>
   line.length + word.length + 1 <= lineLength || line === ''; //if line is empty always return true
 
-//array reducer
+// array reducer
 const reduceLines = (lineLength) =>
   (lines, word) => {
     return isUnderLimit(lastItem(lines), word, lineLength)
@@ -21,22 +28,39 @@ const reduceLines = (lineLength) =>
       : newLine(lines, word);
   };
 
-/**
- * transforms a string into an array of word wrapped lines
- * @param {string} text
- * @param {number} lineLength - max length of a line
- * @returns {string[]}
- */
-export const wordWrap = (text, lineLength) => {
-  return text.split(' ')
-    .filter((e) => e !== '')
-    .reduce(reduceLines(lineLength), [''])
-    .map((e) => e.trim());
-};
+// word wrap transformations
+const spiltToWords = pipeCompatibleSplit(' ');
+const removeExtraSpaces = pipeCompatibleFilter((word) => word !== '');
+
+const reduceToLines = (maxLineLength) =>
+  pipeCompatibleReduce(reduceLines(maxLineLength))(['']);
+
+const passPropertiesToLInes = (propertiesToPass) =>
+  pipeCompatibleMap((line) => ({
+    text: line.trim(),
+    ...propertiesToPass,
+  }));
+
+// apply transformations in order with pipe
+const applyWordWrap = ({ text, wordWrap, ...menuItemProperties }) =>
+  pipe(
+    spiltToWords,
+    removeExtraSpaces,
+    reduceToLines(wordWrap),
+    passPropertiesToLInes(menuItemProperties),
+  )(text);
+
+// entry layer conditional logic
+const hasWordWrap = (item) => !!item.wordWrap;
+// deno-lint-ignore no-unused-vars
+const ignoreWordWrap = ({ wordWrap, ...item }) => item;
+
+// entry layer
+export const wordWrap = (menuItem) =>
+  hasWordWrap(menuItem) ? applyWordWrap(menuItem) : [ignoreWordWrap(menuItem)];
 
 /**
  * returns true if XBARDarkMode is enabled.
- *
  * allways returns false if 'env' permission has not been previously granted.
  * @async
  * @returns {Promise<boolean>}

--- a/src/format.js
+++ b/src/format.js
@@ -1,0 +1,29 @@
+import { pipe, pipeCompatibleReduce } from './utility.js';
+
+// line Object access layer
+const getText = (lineObj) => lineObj.text ?? '';
+const getSubMenuLevel = (lineObj) => lineObj.submenuLevel;
+// deno-lint-ignore no-unused-vars
+const ignoreSubMenuLevel = ({ submenuLevel, ...lineObj }) => lineObj;
+// deno-lint-ignore no-unused-vars
+const ignoreText = ({ text, ...lineObj }) => lineObj;
+
+// line formatting layer
+const getSubMenuFormatting = (lineObj) => '--'.repeat(getSubMenuLevel(lineObj));
+const getFormattedText = (lineObj) => `${getText(lineObj)}`.trim();
+const formatOutputOptions = pipeCompatibleReduce((output, [option, value]) =>
+  output.concat(` | ${option}=${value}`)
+)('');
+
+const getFormattedOutputOptions = pipe(
+  ignoreText,
+  ignoreSubMenuLevel,
+  Object.entries,
+  formatOutputOptions,
+);
+
+// entry layer
+export const formatLine = (lineObj) =>
+  getSubMenuFormatting(lineObj) +
+  getFormattedText(lineObj) +
+  getFormattedOutputOptions(lineObj);

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,58 @@
+import { pipe, pipeCompatibleMap } from './utility.js';
+import { wordWrap } from './accessibility.js';
+import { formatLine } from './format.js';
+
+// item layer
+const isSeparator = (item) => item === separator;
+
+const hasSubmenu = (item) => !!item.submenu;
+
+const getSubmenu = (item) =>
+  item.submenu.map((e) => ({
+    ...e,
+    submenuLevel: item.submenuLevel ? item.submenuLevel + 1 : 1,
+  }));
+
+// deno-lint-ignore no-unused-vars
+const ignoreSubmenu = ({ submenu, ...item }) => item;
+
+const formatItem = pipe(wordWrap, pipeCompatibleMap(formatLine));
+
+// array layer
+const addItem = (arr, item) => [
+  ...arr,
+  ...formatItem(item),
+];
+
+const addItemWithSubmenu = (arr, item) => [
+  ...addItem(arr, ignoreSubmenu(item)),
+  ...pipe(getSubmenu, xbar)(item),
+];
+
+const includeSeparator = (arr) => [
+  ...arr,
+  formatLine(separator),
+];
+
+//entry layer
+/**
+ * Prints output to xbar and returns printed output as an array of strings
+ * @param layout - array of menu items
+ * @returns {string[]} array of strings that were printed as menu items
+ */
+export const xbar = (layout) =>
+  layout.reduce((menuItems, item) => {
+    switch (true) {
+      case (isSeparator(item)):
+        return includeSeparator(menuItems);
+      case (hasSubmenu(item)):
+        return addItemWithSubmenu(menuItems, item);
+      default:
+        return addItem(menuItems, item);
+    }
+  }, []);
+
+/** used for declaring a separator*/
+export const separator = {
+  text: '---',
+};

--- a/src/utility.js
+++ b/src/utility.js
@@ -1,0 +1,14 @@
+export const pipe = (...functions) =>
+  (x) =>
+    functions.reduce(
+      (acc, fn) => fn(acc),
+      x,
+    );
+
+export const pipeCompatibleMap = (callback) => (target) => target.map(callback);
+export const pipeCompatibleReduce = (callback) =>
+  (initValue) => (target) => target.reduce(callback, initValue);
+export const pipeCompatibleSplit = (separator) =>
+  (target) => target.split(separator);
+export const pipeCompatibleFilter = (callback) =>
+  (target) => target.filter(callback);

--- a/test/accessibility.test.js
+++ b/test/accessibility.test.js
@@ -1,45 +1,164 @@
 import { assertEquals } from 'https://deno.land/std@0.128.0/testing/asserts.ts';
 import { wordWrap } from '../src/accessibility.js';
 
-Deno.test('wordWrap splits a string into an array of lines ', () => {
-  const input =
-    'Sometimes science is more art than science, Morty. A lot of people dont get that';
+Deno.test('wordWrap splits a string into an array of lines', () => {
+  const input = {
+    text:
+      'Sometimes science is more art than science, Morty. A lot of people dont get that',
+    wordWrap: 30,
+  };
   const expected = [
-    'Sometimes science is more art',
-    'than science, Morty. A lot of',
-    'people dont get that',
+    {
+      text: 'Sometimes science is more art',
+    },
+    {
+      text: 'than science, Morty. A lot of',
+    },
+    {
+      text: 'people dont get that',
+    },
   ];
-  const actual = wordWrap(input, 30);
+  assertEquals(wordWrap(input), expected);
+});
+
+Deno.test('wordWrap keeps object feilds other than wordWrap constant', () => {
+  const input = {
+    text:
+      'Sometimes science is more art than science, Morty. A lot of people dont get that',
+    wordWrap: 30,
+    color: 'red',
+    size: 12,
+  };
+  const expected = [
+    {
+      text: 'Sometimes science is more art',
+      color: 'red',
+      size: 12,
+    },
+    {
+      text: 'than science, Morty. A lot of',
+      color: 'red',
+      size: 12,
+    },
+    {
+      text: 'people dont get that',
+      color: 'red',
+      size: 12,
+    },
+  ];
+  const actual = wordWrap(input);
   assertEquals(actual, expected);
 });
 
-Deno.test('wordWrap places words longer than max line length on their own line', () => {
-  const input = 'the word implementation is long';
-  const lineLenth = 12;
-  const result = wordWrap(input, lineLenth);
+Deno.test('wordWrap does not split words longer than the max line length into multiple lines', () => {
+  const input = {
+    text: 'the word implementation is long',
+    wordWrap: 12,
+  };
+  const result = wordWrap(input);
 
-  const expected = ['the word', 'implementation', 'is long'];
-
+  const expected = [
+    {
+      text: 'the word',
+    },
+    {
+      text: 'implementation',
+    },
+    {
+      text: 'is long',
+    },
+  ];
   assertEquals(result, expected);
 });
 
 Deno.test('wordWrap only includes one space between words', () => {
-  const input = 'Making    things      easy is    hard';
-  const expected = ['Making things easy', 'is hard'];
-  const actual = wordWrap(input, 20);
+  const input = {
+    text: 'Making    things      easy is    hard',
+    wordWrap: 20,
+  };
+  const expected = [
+    {
+      text: 'Making things easy',
+    },
+    {
+      text: 'is hard',
+    },
+  ];
+  const actual = wordWrap(input);
   assertEquals(actual, expected);
 });
 
 Deno.test('wordWrap does not split a string into multiple lines if the string is not longer than the max line length', () => {
-  const input =
-    'Program testing can be used to show the presence of bugs, but never to show their absence';
-  const actual = wordWrap(input, 9999);
-  assertEquals(actual, [input]);
+  const input = {
+    text:
+      'Program testing can be used to show the presence of bugs, but never to show their absence',
+    wordWrap: 9999,
+  };
+  const actual = wordWrap(input);
+  assertEquals(actual, [{ text: input.text }]);
 });
 
 Deno.test('wordWrap returns only 1 line per word if every word is longer than max line limit', () => {
-  const input = 'walla walla washington';
-  const expected = ['walla', 'walla', 'washington'];
-  const actual = wordWrap(input, 4);
+  const input = {
+    text: 'walla walla washington',
+    wordWrap: 4,
+  };
+  const expected = [
+    {
+      text: 'walla',
+    },
+    {
+      text: 'walla',
+    },
+    {
+      text: 'washington',
+    },
+  ];
+  const actual = wordWrap(input);
   assertEquals(actual, expected);
+});
+
+Deno.test('wordWrap does not return an object with a `wordWrap` field if input object contains a `wordWrap` field with a falsy value', () => {
+  const input = [
+    {
+      text: 'Code never lies, sometimes comments do',
+      wordWrap: false,
+    },
+    {
+      text: 'JavaScript making 0 falsy was a mistake',
+      wordWrap: 0,
+    },
+    {
+      text: 'undefined is well defined',
+      wordWrap: undefined,
+    },
+    {
+      text: 'intentional absence of a value should not carry pass this point',
+      wordWrap: null,
+    },
+    {
+      text: 'NaN does not equal NaN',
+      wordWrap: NaN,
+    },
+  ];
+  const expected = [
+    {
+      text: 'Code never lies, sometimes comments do',
+    },
+    {
+      text: 'JavaScript making 0 falsy was a mistake',
+    },
+    {
+      text: 'undefined is well defined',
+    },
+    {
+      text: 'intentional absence of a value should not carry pass this point',
+    },
+    {
+      text: 'NaN does not equal NaN',
+    },
+  ];
+  input.forEach((item, i) => {
+    assertEquals(wordWrap(item), [expected[i]]);
+  });
 });

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -1,0 +1,64 @@
+import {
+  assert,
+  assertEquals,
+} from 'https://deno.land/std@0.128.0/testing/asserts.ts';
+import { formatLine } from '../src/format.js';
+Deno.test('formatLine returns a string', () => {
+  const input = {
+    text:
+      'Sometimes science is more art than science, Morty. A lot of people dont get that',
+  };
+  const output = formatLine(input);
+  assert(typeof output === 'string');
+});
+
+Deno.test('formatLine formats submenulevel as hyphens', () => {
+  const input = {
+    text:
+      'The computer industry is the only industry that is more fashion-driven than womens fashion',
+    submenuLevel: 3,
+  };
+  const output = formatLine(input);
+  assert(output.includes('--'));
+  assert(!output.includes('submenuLevel'));
+});
+
+Deno.test('formatLine does not include leading or trailing spaces in output string', () => {
+  const input = {
+    text: '  Making things easy is hard   ',
+  };
+
+  const output = formatLine(input);
+  assertEquals(output, 'Making things easy is hard');
+});
+
+Deno.test('formatLine outputs numeric values as strings', () => {
+  const input = {
+    text: 100,
+    size: 20,
+  };
+  const output = formatLine(input);
+  assertEquals(output, '100 | size=20');
+});
+
+Deno.test('formatLine includes falsy values in output', () => {
+  const input = {
+    text: 'making everything true or false has its downsides',
+    emojize: false,
+  };
+
+  const output = formatLine(input);
+  assertEquals(
+    output,
+    'making everything true or false has its downsides | emojize=false',
+  );
+});
+
+Deno.test('formatLine will format an object that does not include a text feild', () => {
+  const input = {
+    color: 'red',
+  };
+
+  const output = formatLine(input);
+  assertEquals(output, ' | color=red');
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,73 @@
+import {
+  assert,
+  assertEquals,
+} from 'https://deno.land/std@0.128.0/testing/asserts.ts';
+import { separator, xbar } from '../src/index.js';
+
+Deno.test('xbar returns separator as ---', () => {
+  const input = [separator];
+  const actual = xbar(input);
+  assertEquals(actual, ['---']);
+});
+
+Deno.test('xbar returns an array of strings', () => {
+  const input = [
+    {
+      text: 'Making things easy is hard',
+    },
+    separator,
+    {
+      text: 'second text',
+      color: 'red',
+      submenu: [
+        {
+          text: 'submenu text',
+        },
+      ],
+    },
+  ];
+  const actual = xbar(input);
+  actual.forEach((element) => {
+    assert(typeof element === 'string');
+  });
+});
+
+Deno.test('xbar handles an menu item with a submenu so that the submenu is returned before the next menu item', () => {
+  const input = [
+    {
+      text: 'first',
+    },
+    {
+      text: 'second',
+      submenu: [
+        {
+          text: 'third',
+        },
+      ],
+    },
+    {
+      text: 'fourth',
+    },
+  ];
+  const expected = ['first', 'second', '--third', 'fourth'];
+
+  const actual = xbar(input);
+  assertEquals(actual, expected);
+});
+
+Deno.test('xbar does not apply a menu items properties to a submenu', () => {
+  const input = [
+    {
+      text: 'menu',
+      color: 'red',
+      submenu: [
+        {
+          text: 'submenu',
+        },
+      ],
+    },
+  ];
+  const expected = ['menu | color=red', '--submenu'];
+  const actual = xbar(input);
+  assertEquals(actual, expected);
+});


### PR DESCRIPTION
## Description
Functionality to declaratively create xbar menu layouts was added in three commits. 
1. commit containing a set of utility functions for composing functions with pipes
2. commit reworking wordWrap to take an object instead of a string as a parameter 
3. commit adding a function that transform an xbar menu item into a formatted string, and a function that takes an array of xbar menu items and transforms each item, in the correct order, into a formatted string,  

## Spec
example what this pull request enables.  
 
```
const layout = xbar([
  {
    text: 'Quotes', 
  },
  separator,
  {
    text: jsonData.author,
    submenu: [
      {
        text: jsonData.quote,
        wordWrap: 40,
        size: 16,
        color: 'navy'
      }
    ],
  }
]);

//layout 
[
 'Quotes',
 '---',
 'author',
 '--quote text line 1 | size=16 | color=navy', 
 '--quote text line 2  | size=16 | color=navy',
]
```
See Issue: [FSA22V1-95](https://sparkbox.atlassian.net/browse/FSA22V1-95)

## To Validate

1. Make sure all PR Checks have passed.
2. Check that new tests reflect stated logic 
3. Check that code logic and naming is clear